### PR TITLE
Close LevelDB before installing a snapshot

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -16,6 +16,7 @@
 #include "init.h"
 #include "ui_interface.h"
 #include "qtipcserver.h"
+#include "txdb.h"
 #include "util.h"
 #include "winshutdownmonitor.h"
 #include "upgrade.h"
@@ -260,6 +261,16 @@ int main(int argc, char *argv[])
     if (fSnapshotRequest)
     {
         UpgradeQt test;
+
+        // Release LevelDB file handles on Windows so we can remove the old
+        // blockchain files:
+        //
+        // We should really close it in Shutdown() when the main application
+        // exits. Before we can do that, we need to solve an old outstanding
+        // conflict with the behavior of "-daemon" on Linux that prematurely
+        // closes the DB when the process forks.
+        //
+        CTxDB().Close();
 
         if (test.SnapshotMain())
             LogPrintf("Snapshot: Success!");


### PR DESCRIPTION
This instructs LevelDB to release the file handles it opened so that the snapshot install process can remove the old blockchain files on Windows.

Ideally, we should close LevelDB in the main application's `Shutdown()` handler. It did this before (the code is commented-out), but there's an outstanding issue with the `-daemon` behavior on Linux when the process forks (the `Shutdown()` handler from the parent process closes LevelDB while the child still uses it). Maybe @denravonska can shed some more light on that. For now, this fixes the open file handle issue on Windows that blocks the snapshot clean-up stage.